### PR TITLE
feat: middleware de rutas + migración tokens a cookies (#8)

### DIFF
--- a/features/auth/components/FormAdminLogin/index.tsx
+++ b/features/auth/components/FormAdminLogin/index.tsx
@@ -21,7 +21,7 @@ export default function FormAdminLogin() {
 		setIsLoading(true)
 		try {
 			const response = await adminLogin({ identifier, password })
-			setTokens(response.accessToken, response.refreshToken)
+			setTokens(response.accessToken, response.refreshToken, response.user.role)
 			router.push(ROUTES_APP.ADMIN_DASHBOARD.path)
 		} catch {
 			setError('Credenciales incorrectas. Intenta de nuevo.')

--- a/features/auth/components/FormVerification/index.tsx
+++ b/features/auth/components/FormVerification/index.tsx
@@ -38,7 +38,7 @@ export default function FormVerification() {
 		setIsLoading(true)
 		try {
 			const response = await verifyOtp({ phone, code })
-			setTokens(response.accessToken, response.refreshToken)
+			setTokens(response.accessToken, response.refreshToken, response.user.role)
 			if (response.user.status === 'ENABLED') {
 				if (response.user.role === 'ADMIN') {
 					router.push(ROUTES_APP.ADMIN_DASHBOARD.path)

--- a/lib/axios.ts
+++ b/lib/axios.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosError } from 'axios'
+import { getCookie, clearCookies } from '@/shared/utils/cookies'
 
 const API = axios.create({
 	baseURL: process.env.NEXT_PUBLIC_API_URL,
@@ -11,7 +12,7 @@ const API = axios.create({
 
 API.interceptors.request.use((config) => {
 	if (typeof window !== 'undefined') {
-		const token = localStorage.getItem('token')
+		const token = getCookie('access_token')
 		if (token) config.headers.Authorization = `Bearer ${token}`
 	}
 	return config
@@ -23,8 +24,7 @@ API.interceptors.response.use(
 		const err = error as AxiosError<{ message?: string }>
 		if (err.response?.status === 401) {
 			if (typeof window !== 'undefined') {
-				localStorage.removeItem('token')
-				localStorage.removeItem('refreshToken')
+				clearCookies()
 				// window.location.href = '/'
 			}
 		}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { PUBLIC_ROUTES, AUTH_ROUTES } from '@/shared/utils/constants'
+
+export function middleware(request: NextRequest) {
+	const { pathname } = request.nextUrl
+
+	const accessToken = request.cookies.get('access_token')?.value
+	const userRole = request.cookies.get('user_role')?.value as
+		| 'ADMIN'
+		| 'GROCER'
+		| undefined
+
+	// Rutas públicas — permitir sin verificar
+	const isPublicRoute = PUBLIC_ROUTES.some((route) =>
+		pathname.startsWith(route),
+	)
+	if (isPublicRoute) return NextResponse.next()
+
+	// Rutas protegidas — verificar sesión y rol
+	const isAuthRoute = AUTH_ROUTES.some((route) => pathname.startsWith(route))
+	if (isAuthRoute) {
+		// Sin token → redirigir a login
+		if (!accessToken || !userRole) {
+			return NextResponse.redirect(new URL('/inicia-sesion', request.url))
+		}
+
+		// GROCER intentando acceder a /admin → redirigir a /tienda
+		if (userRole === 'GROCER' && pathname.startsWith('/admin')) {
+			return NextResponse.redirect(new URL('/tienda', request.url))
+		}
+
+		// ADMIN intentando acceder a /tienda → redirigir a /admin
+		if (userRole === 'ADMIN' && pathname.startsWith('/tienda')) {
+			return NextResponse.redirect(new URL('/admin', request.url))
+		}
+	}
+
+	return NextResponse.next()
+}
+
+export const config = {
+	matcher: [
+		'/((?!_next/static|_next/image|favicon.ico|icons|og-image.png).*)',
+	],
+}

--- a/shared/hooks/useAuth.ts
+++ b/shared/hooks/useAuth.ts
@@ -5,53 +5,56 @@ import { ROUTES_APP } from '@/shared/utils/constants'
 import { clearTokens, setTokens, getUserRole, isTokenExpired } from '@/shared/utils/auth'
 
 export const useAuth = () => {
-  const router = useRouter()
-  const [isLoading, setIsLoading] = useState(true)
-  const [isAuthenticated, setIsAuthenticated] = useState(false)
-  const [role, setRole] = useState<'ADMIN' | 'GROCER' | null>(null)
+	const router = useRouter()
+	const [isLoading, setIsLoading] = useState(true)
+	const [isAuthenticated, setIsAuthenticated] = useState(false)
+	const [role, setRole] = useState<'ADMIN' | 'GROCER' | null>(null)
 
-  useEffect(() => {
-    checkAuth()
-  }, [])
+	useEffect(() => {
+		checkAuth()
+	}, [])
 
-  const checkAuth = () => {
-    if (typeof window === 'undefined') return
-    try {
-      if (isTokenExpired()) {
-        clearTokens()
-        setIsAuthenticated(false)
-        setRole(null)
-      } else {
-        const userRole = getUserRole()
-        setIsAuthenticated(true)
-        setRole(userRole)
-      }
-    } catch {
-      setIsAuthenticated(false)
-      setRole(null)
-    } finally {
-      setIsLoading(false)
-    }
-  }
+	const checkAuth = () => {
+		if (typeof window === 'undefined') return
+		try {
+			if (isTokenExpired()) {
+				clearTokens()
+				setIsAuthenticated(false)
+				setRole(null)
+			} else {
+				const userRole = getUserRole()
+				setIsAuthenticated(true)
+				setRole(userRole)
+			}
+		} catch {
+			setIsAuthenticated(false)
+			setRole(null)
+		} finally {
+			setIsLoading(false)
+		}
+	}
 
-  const login = (accessToken: string, refreshToken: string) => {
-    setTokens(accessToken, refreshToken)
-    const userRole = getUserRole()
-    setIsAuthenticated(true)
-    setRole(userRole)
-    if (userRole === 'ADMIN') {
-      router.push(ROUTES_APP.ADMIN_DASHBOARD.path)
-    } else {
-      router.push(ROUTES_APP.DASHBOARD.path)
-    }
-  }
+	const login = (
+		accessToken: string,
+		refreshToken: string,
+		userRole: 'ADMIN' | 'GROCER',
+	) => {
+		setTokens(accessToken, refreshToken, userRole)
+		setIsAuthenticated(true)
+		setRole(userRole)
+		if (userRole === 'ADMIN') {
+			router.push(ROUTES_APP.ADMIN_DASHBOARD.path)
+		} else {
+			router.push(ROUTES_APP.DASHBOARD.path)
+		}
+	}
 
-  const logout = () => {
-    clearTokens()
-    setIsAuthenticated(false)
-    setRole(null)
-    router.push(ROUTES_APP.HOME.path)
-  }
+	const logout = () => {
+		clearTokens()
+		setIsAuthenticated(false)
+		setRole(null)
+		router.push(ROUTES_APP.HOME.path)
+	}
 
-  return { isAuthenticated, isLoading, role, login, logout, checkAuth }
+	return { isAuthenticated, isLoading, role, login, logout, checkAuth }
 }

--- a/shared/utils/auth.ts
+++ b/shared/utils/auth.ts
@@ -1,40 +1,44 @@
 import { JwtPayload } from '@/features/auth/types/types'
+import { setCookies, getCookie, clearCookies } from '@/shared/utils/cookies'
 
 export function getToken(): string | null {
-  if (typeof window === 'undefined') return null
-  return localStorage.getItem('token')
+	return getCookie('access_token')
 }
 
-export function setTokens(accessToken: string, refreshToken: string): void {
-  localStorage.setItem('token', accessToken)
-  localStorage.setItem('refreshToken', refreshToken)
+export function setTokens(
+	accessToken: string,
+	refreshToken: string,
+	role: 'ADMIN' | 'GROCER',
+): void {
+	setCookies(accessToken, refreshToken, role)
 }
 
 export function clearTokens(): void {
-  localStorage.removeItem('token')
-  localStorage.removeItem('refreshToken')
+	clearCookies()
 }
 
 export function parseJwt(token: string): JwtPayload | null {
-  try {
-    const base64 = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')
-    return JSON.parse(atob(base64)) as JwtPayload
-  } catch {
-    return null
-  }
+	try {
+		const base64 = token
+			.split('.')[1]
+			.replace(/-/g, '+')
+			.replace(/_/g, '/')
+		return JSON.parse(atob(base64)) as JwtPayload
+	} catch {
+		return null
+	}
 }
 
 export function getUserRole(): 'ADMIN' | 'GROCER' | null {
-  const token = getToken()
-  if (!token) return null
-  const payload = parseJwt(token)
-  return payload?.role ?? null
+	const role = getCookie('user_role')
+	if (role === 'ADMIN' || role === 'GROCER') return role
+	return null
 }
 
 export function isTokenExpired(): boolean {
-  const token = getToken()
-  if (!token) return true
-  const payload = parseJwt(token)
-  if (!payload) return true
-  return Date.now() >= payload.exp * 1000
+	const token = getToken()
+	if (!token) return true
+	const payload = parseJwt(token)
+	if (!payload) return true
+	return Date.now() >= payload.exp * 1000
 }

--- a/shared/utils/cookies.ts
+++ b/shared/utils/cookies.ts
@@ -1,0 +1,48 @@
+'use client'
+
+const COOKIE_ACCESS_TOKEN = 'access_token'
+const COOKIE_REFRESH_TOKEN = 'refresh_token'
+const COOKIE_USER_ROLE = 'user_role'
+
+function setCookie(name: string, value: string, days = 7): void {
+	if (typeof document === 'undefined') return
+	const expires = new Date()
+	expires.setDate(expires.getDate() + days)
+	document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires.toUTCString()}; path=/; SameSite=Lax`
+}
+
+function getCookieValue(name: string): string | null {
+	if (typeof document === 'undefined') return null
+	const match = document.cookie
+		.split('; ')
+		.find((row) => row.startsWith(`${name}=`))
+	if (!match) return null
+	return decodeURIComponent(match.split('=')[1])
+}
+
+function deleteCookie(name: string): void {
+	if (typeof document === 'undefined') return
+	document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Lax`
+}
+
+export function setCookies(
+	accessToken: string,
+	refreshToken: string,
+	role: 'ADMIN' | 'GROCER',
+): void {
+	setCookie(COOKIE_ACCESS_TOKEN, accessToken)
+	setCookie(COOKIE_REFRESH_TOKEN, refreshToken)
+	setCookie(COOKIE_USER_ROLE, role)
+}
+
+export function getCookie(
+	name: 'access_token' | 'refresh_token' | 'user_role',
+): string | null {
+	return getCookieValue(name)
+}
+
+export function clearCookies(): void {
+	deleteCookie(COOKIE_ACCESS_TOKEN)
+	deleteCookie(COOKIE_REFRESH_TOKEN)
+	deleteCookie(COOKIE_USER_ROLE)
+}


### PR DESCRIPTION
## Descripción

Implementa el middleware de Next.js para proteger rutas según sesión y rol, migrando el almacenamiento de tokens de `localStorage` a cookies HTTP para que el middleware pueda leerlos en el Edge Runtime.

## Cambios

### Nuevos archivos
- **`shared/utils/cookies.ts`** — helpers `setCookies`, `getCookie`, `clearCookies` para manejo de cookies desde el cliente
- **`middleware.ts`** — protección de rutas por sesión y rol

### Modificados
- **`shared/utils/auth.ts`** — migrado de `localStorage` a cookies; `setTokens()` ahora recibe `role` como tercer parámetro; `getUserRole()` lee desde cookie `user_role`
- **`lib/axios.ts`** — lee `access_token` desde cookies en lugar de `localStorage`
- **`shared/hooks/useAuth.ts`** — `login()` recibe `role` explícito como tercer parámetro
- **`features/auth/components/FormVerification/index.tsx`** — pasa `response.user.role` a `setTokens()`
- **`features/auth/components/FormAdminLogin/index.tsx`** — pasa `response.user.role` a `setTokens()`

## Flujo del middleware

```
Request entrante
    │
    ├── ¿Ruta pública? → Permitir
    │
    ├── ¿Ruta protegida? (/tienda, /admin)
    │       ├── Sin token → Redirigir a /inicia-sesion
    │       ├── GROCER en /admin → Redirigir a /tienda
    │       └── ADMIN en /tienda → Redirigir a /admin
    │
    └── Cualquier otra ruta → Permitir
```

## Criterios de aceptación

- [x] Acceder a `/tienda` o `/admin` sin sesión redirige a `/inicia-sesion`
- [x] GROCER no puede acceder a `/admin` — redirige a `/tienda`
- [x] ADMIN no puede acceder a `/tienda` — redirige a `/admin`
- [x] Rutas públicas accesibles sin sesión
- [x] Después del login, `access_token`, `refresh_token` y `user_role` existen como cookies
- [x] Después del logout, las tres cookies son eliminadas
- [x] El interceptor de Axios sigue enviando `Authorization: Bearer` correctamente
- [x] El middleware no rompe rutas de assets

Closes #8